### PR TITLE
Some performance optimizations

### DIFF
--- a/DCIT_Tool/disambiguate.py
+++ b/DCIT_Tool/disambiguate.py
@@ -92,14 +92,29 @@ def disambiguate(tweets, dcons, zeros_limit = 0.8):
 	for i in new_dcons:
 		print i.part_one[0]
 
-	def loop_content(t):
-		tagged_path = "../tweets-POS_tagged/"+t.filename + "-tagged.txt"
-		tagged = open(tagged_path)
-		
-		for line in tagged:
-			# find line that matches (maybe too slow for big files? use grep?)
-			if line.find(t.id) >= 0:
+	
+	current_file = {"name": None, "data": None}
+	id_regex = re.compile(r'^\t+(\d)+\t(.*)$')
+	
+	def load_tagged_file(filename):
+		if current_file["name"] != filename:
+			data = dict()
+			current_file["name"] = filename
+			current_file["data"] = data
+			tagged_path = "../tweets-POS_tagged/"+t.filename + "-tagged.txt"
+			tagged = open(tagged_path)
 			
+			for line in tagged:
+				match = id_regex.match(line)
+				if(match):
+					id = match.group(1)
+					rest = match.group(2)
+					data[id] = rest
+		return current_file["data"]
+
+	def loop_content(t, data):
+		line = data.get(t.id)
+		if(line):
 				# remains unchanged
 				results = re.findall(pattern,line)
 				instances = {}
@@ -120,4 +135,5 @@ def disambiguate(tweets, dcons, zeros_limit = 0.8):
 		return t
 	
 	for t in tweets:
-		yield loop_content(t)
+		data = load_tagged_file(t.filename)
+		yield loop_content(t, data)

--- a/DCIT_Tool/disambiguate.py
+++ b/DCIT_Tool/disambiguate.py
@@ -92,7 +92,7 @@ def disambiguate(tweets, dcons, zeros_limit = 0.8):
 	for i in new_dcons:
 		print i.part_one[0]
 
-	for t in tweets:
+	def loop_content(t):
 		tagged_path = "../tweets-POS_tagged/"+t.filename + "-tagged.txt"
 		tagged = open(tagged_path)
 		
@@ -117,5 +117,7 @@ def disambiguate(tweets, dcons, zeros_limit = 0.8):
 									pass
 					elif schneiders[j][2]:
 						pass
-						
-		yield t
+		return t
+	
+	for t in tweets:
+		yield loop_content(t)

--- a/DCIT_Tool/get_matches.py
+++ b/DCIT_Tool/get_matches.py
@@ -15,7 +15,8 @@ def get_matches(tweets, dcons, info):
 	contins = [i for i in dcons if i.sep == "cont"]
 
 	# info object now updated as we go
-	for t in tweets:	# this is an iterator
+	
+	def loop_contents(t):
 
 		info.tweets += 1	# number of Tweets seen so far
 		tweet_trigger = False
@@ -119,7 +120,9 @@ def get_matches(tweets, dcons, info):
 	
 		info.discontinuous_ambi += t.ambi_count_discontins
 		info.continuous_ambi += t.ambi_count_contins
-	
+
+	for t in tweets:	# this is an iterator
+		loop_contents(t)
 		# this is another iterator
 		yield t
 

--- a/DCIT_Tool/test.py
+++ b/DCIT_Tool/test.py
@@ -28,9 +28,10 @@ def main ():
 	
 	days = []
 	# Get all files in filepath_tweetdirectory (only those for which we also have tagged).
-	#days = glob.glob(filepath_tweetdirectory+"*.xml")
+	days = glob.glob(filepath_tweetdirectory+"*.xml")
+	days = days[0:1]
 	# TESTING.
-	days = filepath_tweetdirectory+"toy.xml"
+	#days = filepath_tweetdirectory+"toy.xml"
 
 	"""
 	# using all the days we have
@@ -53,12 +54,12 @@ def main ():
 	disambiguated_tweets = disambiguate(matched_tweets, dcons)
 #	matched_disambiguated_tweets = get_matches(disambiguated_tweets, contins, discontins, tweetinfo_postdisambiguation)
 	
-	write_results(disambiguated_tweets, filepath_tweetdirectory, filepath_output)
+	#write_results(disambiguated_tweets, filepath_tweetdirectory, filepath_output)
 	
 	# Not Needed Now Because Write Does It.
 	# this is needed because due to the iterator, disambiguated_tweets is generated on demand
-	#for t in disambiguated_tweets:
-	#	continue
+	for t in disambiguated_tweets:
+		continue
 	"""	
 	print "\n\n"
 	print "-- PRE-DISAMBIGUATION"

--- a/DCIT_Tool/test.py
+++ b/DCIT_Tool/test.py
@@ -54,12 +54,12 @@ def main ():
 	disambiguated_tweets = disambiguate(matched_tweets, dcons)
 #	matched_disambiguated_tweets = get_matches(disambiguated_tweets, contins, discontins, tweetinfo_postdisambiguation)
 	
-	#write_results(disambiguated_tweets, filepath_tweetdirectory, filepath_output)
+	write_results(disambiguated_tweets, filepath_tweetdirectory, filepath_output)
 	
 	# Not Needed Now Because Write Does It.
 	# this is needed because due to the iterator, disambiguated_tweets is generated on demand
-	for t in disambiguated_tweets:
-		continue
+	#for t in disambiguated_tweets:
+	#	continue
 	"""	
 	print "\n\n"
 	print "-- PRE-DISAMBIGUATION"

--- a/DCIT_Tool/write_results.py
+++ b/DCIT_Tool/write_results.py
@@ -7,12 +7,15 @@
 from bs4 import BeautifulSoup
 
 def write_results(tweets, input_path, output_path):
+	# these are needed here (and as arrays or similar), because they
+	# are assigned in nested functions.
 	currentfile = [None]
+	soup = [None]
 	
 	def write():
 		if currentfile[0] != None:
 			outfile = open(output_path+currentfile+"_new.xml",'w')
-			outfile.write(soup.prettify().encode("utf-8"))
+			outfile.write(soup[0].prettify().encode("utf-8"))
 			#outfile.write(unicode(soup).encode("utf-8")) # without indenting and w/ wonky newlines
 			outfile.close()
 
@@ -23,11 +26,11 @@ def write_results(tweets, input_path, output_path):
 			# every time we see a new file, write old one and open new one
 			write()	
 			currentfile[0] = t.filename
-			soup = BeautifulSoup(open(input_path+currentfile[0]), "html")
+			soup[0] = BeautifulSoup(open(input_path+currentfile[0]), "html")
 	
 		# modify soup
 		
-		results = soup.findAll("tweet", {"id" : t.id})
+		results = soup[0].findAll("tweet", {"id" : t.id})
 		# there should always be one and only one match, hence results[0]
 		# add some additional attributes (just an example)
 		results[0]["hasDC"] = t.has_dc

--- a/DCIT_Tool/write_results.py
+++ b/DCIT_Tool/write_results.py
@@ -7,23 +7,23 @@
 from bs4 import BeautifulSoup
 
 def write_results(tweets, input_path, output_path):
-	currentfile = None
+	currentfile = [None]
 	
 	def write():
-		if currentfile != None:
+		if currentfile[0] != None:
 			outfile = open(output_path+currentfile+"_new.xml",'w')
 			outfile.write(soup.prettify().encode("utf-8"))
 			#outfile.write(unicode(soup).encode("utf-8")) # without indenting and w/ wonky newlines
 			outfile.close()
-	
-	for t in tweets:
+
+	def loop_content(t):
 		# For D-Buggin'
 		#t.print_dcs()
-		if t.filename != currentfile:
+		if t.filename != currentfile[0]:
 			# every time we see a new file, write old one and open new one
 			write()	
-			currentfile = t.filename
-			soup = BeautifulSoup(open(input_path+currentfile), "html")
+			currentfile[0] = t.filename
+			soup = BeautifulSoup(open(input_path+currentfile[0]), "html")
 	
 		# modify soup
 		
@@ -32,5 +32,8 @@ def write_results(tweets, input_path, output_path):
 		# add some additional attributes (just an example)
 		results[0]["hasDC"] = t.has_dc
 		results[0]["hasAmbiDC"] = t.has_ambi_dc
+
+	for t in tweets:
+		loop_content(t)
 		
 	write() # write the last one


### PR DESCRIPTION
I tried to run the python profiler on the program:

```
   python -m cProfile -s cumulative  ./test.py
```

(from the DCIT_Tool directory)

This outputs (after running the program) a list of all functions and how long they each took, sorted by cumulative time (i.e. including functions called from there). (As the program runs quite long, you might want to press Ctrl-C after some time, the profiling information will still be printed.)

(With `-s tottime` it sorts instead by the total time of each function, not including called functions.)

The result was a bit difficult to analyze, as due to the iterator setup, actually all calculation happens inside the last function which iterates over the iterator.
To make this a bit easier to distinguish, I separated the loop contents in each of the iterator functions into a separate function, which then gets called from the loop after retrieving stuff from the incoming iterator and before yielding to the outgoing iterator.
This is the first commit. (I also commented in/out some unrelated stuff in the test.py to ease my testing – feel free to revert this.) (The third commit fixes write_results, which I broke with the first commit.)

Then I discovered one hot spot in `disambiguate`, the program opened the (mostly same) tagged file for each tweet again and iterated over all the lines. This made an originally linear program quadratic in the number of lines in both files.
I changed this so the file only gets opened and read when it changes, and the content is stored into a dictionary. In the tweet loop then we can simply loop up in the dictionary instead of looping again.
Now the disambiguate part is negligible in the profiler.
(This is the second commit.)
